### PR TITLE
"Exclude File Extension" temporary hotfix

### DIFF
--- a/go/internal/image_processor/worker.go
+++ b/go/internal/image_processor/worker.go
@@ -341,9 +341,10 @@ func (Worker) uploadResults(tmpDir string, resultsDir string, variantsDir string
 
 		sha3 := hex.EncodeToString(h.Sum(nil))
 
+		t := container.Match(data)
+
 		key := path.Join(tsk.Output.Prefix, path.Base(pth))
 
-		t := container.Match(data)
 		if t == matchers.TypeZip {
 			result.ZipOutput = task.ResultZipOutput{
 				Name:         path.Base(pth),
@@ -360,6 +361,10 @@ func (Worker) uploadResults(tmpDir string, resultsDir string, variantsDir string
 				height     int
 				frameCount int
 			)
+
+			if tsk.Output.ExcludeFileExtension && t == matchers.TypeWebp {
+				key = strings.TrimSuffix(key, ".webp")
+			}
 
 			switch t {
 			case matchers.TypeGif, matchers.TypePng:

--- a/go/task/task.go
+++ b/go/task/task.go
@@ -52,8 +52,9 @@ type TaskInput struct {
 }
 
 type TaskOutput struct {
-	Prefix       string `json:"prefix"`
-	ACL          string `json:"acl"`
-	Bucket       string `json:"bucket"`
-	CacheControl string `json:"cache_control"`
+	Prefix               string `json:"prefix"`
+	ACL                  string `json:"acl"`
+	Bucket               string `json:"bucket"`
+	CacheControl         string `json:"cache_control"`
+	ExcludeFileExtension bool   `json:"exclude_file_extension"` // Temporary compatibility workaround, this omits the file extension for WEBP
 }


### PR DESCRIPTION
Adding an option that allows removing the file extension in the output for `.webp` files. This is a quick fix for the broken compatibility layer for emote urls and applications which don't support api-driven image urls.